### PR TITLE
Update nongraphenelist

### DIFF
--- a/nongraphenelist
+++ b/nongraphenelist
@@ -8,3 +8,4 @@ keybase.io
 google.com
 etherscan.io
 github.io
+ubuntu.com


### PR DESCRIPTION
added ubuntu.com to exceptions, for using, e.g. https://paste.ubuntu.com and other Ubuntu-related links